### PR TITLE
Improve dependency load errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,9 @@ docker rm python-wasm-cli
 - Drag the divider between editor and terminal to resize panels
 - Files persist only during the current session (browser memory)
 - All Python standard library modules are available via Pyodide
+
+## Troubleshooting
+
+If the page shows "Failed to load Pyodide" or "Failed to load Monaco editor",
+ensure your browser can access the CDN resources. A working internet
+connection is required when launching the app.

--- a/public/editor.html
+++ b/public/editor.html
@@ -366,6 +366,16 @@
         let maxOpenTabs = 3;
         let terminalLineCount = 0;
 
+        // Warn if required libraries fail to load
+        setTimeout(() => {
+            if (typeof loadPyodide === 'undefined') {
+                alert('Failed to load Pyodide. Check your network connection.');
+            }
+            if (typeof require === 'undefined') {
+                alert('Failed to load Monaco editor resources. Check your network connection.');
+            }
+        }, 5000);
+
         // Terminal elements
         const terminalOutput = document.getElementById('terminal-output');
         const terminalInput = document.getElementById('terminal-input');

--- a/public/index.html
+++ b/public/index.html
@@ -79,6 +79,13 @@
         const input = document.getElementById('input');
         const inputLine = document.getElementById('input-line');
 
+        // Warn if Pyodide fails to load after a short delay
+        setTimeout(() => {
+            if (typeof loadPyodide === 'undefined') {
+                addOutput('Failed to load Pyodide. Check your network connection.', 'error');
+            }
+        }, 5000);
+
         function addOutput(text, className = '') {
             const line = document.createElement('div');
             line.textContent = text;


### PR DESCRIPTION
## Summary
- show a warning if Pyodide fails to load in terminal mode
- show alerts if Pyodide or Monaco fail to load in editor mode
- document that the IDE needs internet access to fetch dependencies

## Testing
- `node test-editor.js` *(fails: ERR_CERT_AUTHORITY_INVALID)*

------
https://chatgpt.com/codex/tasks/task_e_6851d0aef100833084729cf45906095d